### PR TITLE
fix(typescript): fix type definition path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
   "main": "src/index.ts",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "files": [
     "/android",
     "!/android/build",


### PR DESCRIPTION
## Motivation (required)

Fix typescript `index.d.ts` path.

## Test Plan (required)

```ts
import {launchImageLibrary} from 'react-native-image-picker';
```

and check import fine.

![image](https://user-images.githubusercontent.com/1797699/104941004-dd531000-59f5-11eb-968d-00372035f006.png)
